### PR TITLE
Bugfix. Use the correct config name for each machine

### DIFF
--- a/task4/Vagrantfile
+++ b/task4/Vagrantfile
@@ -11,14 +11,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define "vagrant1" do |vagrant1|
     vagrant1.vm.box = "ubuntu/trusty64"
     vagrant1.vm.network "private_network", ip:"10.0.0.2"
-    config.vm.provider "virtualbox" do |v|
+    vagrant1.vm.provider "virtualbox" do |v|
       v.name = "Ansible 101 - Task 4: Frontend"
     end
   end
   config.vm.define "vagrant2" do |vagrant2|
     vagrant2.vm.box = "ubuntu/trusty64"
     vagrant2.vm.network "private_network", ip:"10.0.0.3"
-    config.vm.provider "virtualbox" do |v|
+    vagrant2.vm.provider "virtualbox" do |v|
       v.name = "Ansible 101 - Task 4: Database"
     end
   end


### PR DESCRIPTION
Fix error:
A VirtualBox machine with the name 'Ansible 101 - Task 4: Database' already exists.
Please use another name or delete the machine with the existing
name, and try again.

:-)
